### PR TITLE
Harmonize panier layout and styling

### DIFF
--- a/app/view/public/panier/panier.php
+++ b/app/view/public/panier/panier.php
@@ -6,7 +6,7 @@
 </section>
 
 <main>
-    <section class="cart-section">
+    <section class="panier-container">
         <div class="container">
             <?php if(isset($_SESSION['cart_message'])): ?>
                 <div class="alert alert-success">
@@ -23,24 +23,29 @@
             <?php endif; ?>
 
             <?php if(empty($data['cart_items'])): ?>
-                <div class="empty-cart">
-                    <div class="empty-cart-icon">
-                        <i class="fas fa-shopping-cart"></i>
+                <div class="panier-vide">
+                    <div class="panier-vide-content">
+                        <div class="panier-vide-icon">
+                            <i class="fas fa-shopping-cart"></i>
+                        </div>
+                        <h2>Votre panier est vide</h2>
+                        <p>Découvrez notre collection d'œuvres d'art uniques</p>
+                        <a href="/catalogue" class="btn btn-primary btn-large">Parcourir le catalogue</a>
                     </div>
-                    <h2>Votre panier est vide</h2>
-                    <p>Découvrez notre collection d'œuvres d'art uniques</p>
-                    <a href="/catalogue" class="btn btn-primary">Parcourir le catalogue</a>
                 </div>
             <?php else: ?>
-                <div class="cart-content">
-                    <div class="cart-items">
-                        <h2>Articles dans votre panier (<?= $data['cart_count'] ?>)</h2>
-                        
+                <div class="panier-content">
+                    <div class="panier-liste">
+                        <div class="panier-header">
+                            <h2>Articles dans votre panier</h2>
+                            <span class="panier-count"><?= $data['cart_count'] ?></span>
+                        </div>
+
                         <?php foreach($data['cart_items'] as $item): ?>
-                            <div class="cart-item">
+                            <div class="panier-item">
                                 <div class="item-image">
                                     <?php if($item['image_url']): ?>
-                                        <img src="/uploads/item/<?= $item['slug'] ?>/<?= $item['image_url'] ?>" 
+                                        <img src="/uploads/item/<?= $item['slug'] ?>/<?= $item['image_url'] ?>"
                                              alt="<?= htmlspecialchars($item['nom']) ?>">
                                     <?php else: ?>
                                         <img src="/api/placeholder/150/150" alt="<?= htmlspecialchars($item['nom']) ?>">
@@ -48,27 +53,27 @@
                                 </div>
                                 
                                 <div class="item-details">
-                                    <h3><?= htmlspecialchars($item['nom']) ?></h3>
+                                    <h3 class="item-title"><?= htmlspecialchars($item['nom']) ?></h3>
                                     <p class="item-price">
                                         <?php if($item['prix_promo']): ?>
-                                            <span class="original-price">€ <?= number_format($item['prix'], 2, ',', ' ') ?></span>
-                                            <span class="promo-price">€ <?= number_format($item['prix_promo'], 2, ',', ' ') ?></span>
+                                            <span class="price-original">€ <?= number_format($item['prix'], 2, ',', ' ') ?></span>
+                                            <span class="price-promo">€ <?= number_format($item['prix_promo'], 2, ',', ' ') ?></span>
                                         <?php else: ?>
-                                            € <?= number_format($item['unit_price'], 2, ',', ' ') ?>
+                                            <span class="price-current">€ <?= number_format($item['unit_price'], 2, ',', ' ') ?></span>
                                         <?php endif; ?>
                                     </p>
                                 </div>
-                                
+
                                 <div class="item-quantity">
                                     <form action="/panier/update" method="POST" class="quantity-form">
                                         <input type="hidden" name="cart_line_id" value="<?= $item['cart_line_id'] ?>">
                                         <label>Quantité:</label>
-                                        <input type="number" name="quantity" value="<?= $item['quantity'] ?>" 
-                                               min="1" max="10" class="quantity-input">
+                                        <input type="number" name="quantity" value="<?= $item['quantity'] ?>"
+                                               min="1" max="10" class="qty-input">
                                         <button type="submit" class="btn-update">Mettre à jour</button>
                                     </form>
                                 </div>
-                                
+
                                 <div class="item-subtotal">
                                     <p class="subtotal-label">Sous-total:</p>
                                     <p class="subtotal-price">€ <?= number_format($item['subtotal'], 2, ',', ' ') ?></p>
@@ -77,7 +82,7 @@
                                 <div class="item-actions">
                                     <form action="/panier/remove" method="POST">
                                         <input type="hidden" name="cart_line_id" value="<?= $item['cart_line_id'] ?>">
-                                        <button type="submit" class="btn-remove" 
+                                        <button type="submit" class="btn-remove"
                                                 onclick="return confirm('Supprimer cet article du panier ?');">
                                             <i class="fas fa-trash"></i>
                                         </button>
@@ -86,20 +91,20 @@
                             </div>
                         <?php endforeach; ?>
                         
-                        <div class="cart-actions">
+                        <div class="panier-actions">
                             <a href="/catalogue" class="btn btn-secondary">Continuer mes achats</a>
-                            <form action="/panier/clear" method="POST" style="display: inline;">
-                                <button type="submit" class="btn btn-danger" 
+                            <form action="/panier/clear" method="POST" class="panier-clear-form">
+                                <button type="submit" class="btn btn-danger"
                                         onclick="return confirm('Vider complètement le panier ?');">
                                     Vider le panier
                                 </button>
                             </form>
                         </div>
                     </div>
-                    
-                    <div class="cart-summary">
+
+                    <div class="summary-card">
                         <h3>Résumé de la commande</h3>
-                        
+
                         <div class="summary-line">
                             <span>Sous-total:</span>
                             <span>€ <?= number_format($data['total'], 2, ',', ' ') ?></span>
@@ -114,11 +119,13 @@
                             <span>Total:</span>
                             <span class="total-price">€ <?= number_format($data['total'], 2, ',', ' ') ?></span>
                         </div>
-                        
-                        <a href="/panier/checkout" class="btn btn-primary btn-block">
-                            Procéder au paiement
-                        </a>
-                        
+
+                        <div class="summary-actions">
+                            <a href="/panier/checkout" class="btn btn-primary btn-block">
+                                Procéder au paiement
+                            </a>
+                        </div>
+
                         <div class="payment-methods">
                             <p>Moyens de paiement acceptés:</p>
                             <div class="payment-icons">
@@ -128,7 +135,7 @@
                                 <i class="fab fa-cc-stripe"></i>
                             </div>
                         </div>
-                        
+
                         <div class="security-info">
                             <i class="fas fa-lock"></i>
                             <p>Paiement 100% sécurisé</p>
@@ -139,173 +146,3 @@
         </div>
     </section>
 </main>
-
-<style>
-.cart-section {
-    padding: 60px 0;
-    min-height: 500px;
-}
-
-.alert {
-    padding: 15px;
-    margin-bottom: 20px;
-    border-radius: 4px;
-}
-
-.alert-success {
-    background-color: #d4edda;
-    border: 1px solid #c3e6cb;
-    color: #155724;
-}
-
-.alert-error {
-    background-color: #f8d7da;
-    border: 1px solid #f5c6cb;
-    color: #721c24;
-}
-
-.empty-cart {
-    text-align: center;
-    padding: 80px 20px;
-}
-
-.empty-cart-icon {
-    font-size: 100px;
-    color: #ddd;
-    margin-bottom: 30px;
-}
-
-.empty-cart h2 {
-    font-size: 2rem;
-    margin-bottom: 15px;
-}
-
-.cart-content {
-    display: grid;
-    grid-template-columns: 1fr 400px;
-    gap: 40px;
-}
-
-.cart-item {
-    display: grid;
-    grid-template-columns: 150px 1fr auto auto auto;
-    gap: 20px;
-    padding: 20px;
-    background: white;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    margin-bottom: 20px;
-    align-items: center;
-}
-
-.item-image img {
-    width: 100%;
-    border-radius: 4px;
-}
-
-.item-details h3 {
-    font-size: 1.2rem;
-    margin-bottom: 10px;
-}
-
-.original-price {
-    text-decoration: line-through;
-    color: #999;
-}
-
-.promo-price {
-    color: #e74c3c;
-    font-weight: bold;
-}
-
-.quantity-input {
-    width: 60px;
-    padding: 5px;
-    margin: 0 10px;
-}
-
-.btn-update {
-    background: #4CAF50;
-    color: white;
-    border: none;
-    padding: 5px 15px;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.btn-remove {
-    background: #e74c3c;
-    color: white;
-    border: none;
-    padding: 10px;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.cart-summary {
-    background: #f8f9fa;
-    padding: 30px;
-    border-radius: 8px;
-    position: sticky;
-    top: 20px;
-}
-
-.summary-line {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 15px;
-    padding-bottom: 15px;
-    border-bottom: 1px solid #dee2e6;
-}
-
-.summary-total {
-    display: flex;
-    justify-content: space-between;
-    font-size: 1.3rem;
-    font-weight: bold;
-    margin: 20px 0;
-}
-
-.btn-block {
-    width: 100%;
-    padding: 15px;
-    font-size: 1.1rem;
-}
-
-.payment-methods {
-    margin-top: 30px;
-    text-align: center;
-}
-
-.payment-icons {
-    display: flex;
-    justify-content: center;
-    gap: 15px;
-    font-size: 2rem;
-    color: #666;
-    margin-top: 10px;
-}
-
-.security-info {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 20px;
-    color: #28a745;
-}
-
-@media (max-width: 1024px) {
-    .cart-content {
-        grid-template-columns: 1fr;
-    }
-    
-    .cart-summary {
-        position: relative;
-    }
-    
-    .cart-item {
-        grid-template-columns: 100px 1fr;
-    }
-}
-</style>

--- a/public/css/styles_panier.css
+++ b/public/css/styles_panier.css
@@ -1,5 +1,15 @@
 @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600;700&family=Montserrat:wght@200;300;400;500&display=swap');
 
+:root {
+    --teal-dark: #1B4D4D;
+    --teal-main: #2A7373;
+    --teal-accent: #3E8B8B;
+    --teal-soft: #E2F0EF;
+    --teal-soft-alt: #F2F8F8;
+    --neutral-dark: #111;
+    --neutral-text: #666;
+}
+
 /* Hero Section */
 .hero {
     height: 300px;
@@ -48,8 +58,9 @@
 
 /* Container principal */
 .panier-container {
-    padding: 80px 0;
-    min-height: 60vh;
+    padding: 60px 0;
+    min-height: 500px;
+    background-color: #fff;
 }
 
 .container {
@@ -73,7 +84,8 @@
 
 .panier-vide-icon {
     font-size: 80px;
-    color: #ccc;
+    color: var(--teal-main);
+    opacity: 0.2;
     margin-bottom: 30px;
 }
 
@@ -81,13 +93,13 @@
     font-family: 'Cormorant Garamond', serif;
     font-size: 36px;
     font-weight: 400;
-    color: #111;
+    color: var(--neutral-dark);
     margin-bottom: 15px;
 }
 
 .panier-vide p {
     font-size: 16px;
-    color: #666;
+    color: var(--neutral-text);
     margin-bottom: 30px;
     line-height: 1.6;
 }
@@ -107,21 +119,36 @@
     margin-bottom: 30px;
     padding-bottom: 20px;
     border-bottom: 2px solid #f0f0f0;
+    color: var(--neutral-dark);
 }
 
 .panier-header h2 {
     font-family: 'Cormorant Garamond', serif;
     font-size: 32px;
     font-weight: 400;
-    color: #111;
+    color: var(--neutral-dark);
+}
+
+.panier-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    height: 36px;
+    padding: 0 12px;
+    border-radius: 999px;
+    background-color: var(--teal-soft);
+    color: var(--teal-dark);
+    font-size: 14px;
+    font-weight: 600;
 }
 
 .btn-clear {
-    color: #dc3545;
+    color: var(--teal-dark);
     text-decoration: none;
     font-size: 14px;
     padding: 8px 16px;
-    border: 1px solid #dc3545;
+    border: 1px solid var(--teal-dark);
     border-radius: 4px;
     transition: all 0.3s ease;
     display: flex;
@@ -130,7 +157,7 @@
 }
 
 .btn-clear:hover {
-    background-color: #dc3545;
+    background-color: var(--teal-dark);
     color: #fff;
 }
 
@@ -141,20 +168,32 @@
     gap: 30px;
 }
 
+.panier-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    align-items: center;
+}
+
+.panier-clear-form {
+    display: inline;
+}
+
 .panier-item {
     display: grid;
-    grid-template-columns: 200px 1fr auto;
+    grid-template-columns: 160px 1fr auto auto auto;
     gap: 30px;
     padding: 30px;
     background-color: #fff;
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--teal-soft);
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
     transition: all 0.3s ease;
+    align-items: center;
 }
 
 .panier-item:hover {
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 24px rgba(27, 77, 77, 0.15);
 }
 
 .item-image {
@@ -181,6 +220,31 @@
     justify-content: space-between;
 }
 
+.item-quantity,
+.item-subtotal,
+.item-actions {
+    justify-self: flex-end;
+}
+
+.item-quantity {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+    font-size: 14px;
+    color: var(--neutral-text);
+}
+
+.item-actions form {
+    display: inline;
+}
+
+.item-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
 .item-title {
     font-family: 'Cormorant Garamond', serif;
     font-size: 24px;
@@ -189,13 +253,13 @@
 }
 
 .item-title a {
-    color: #111;
+    color: var(--neutral-dark);
     text-decoration: none;
     transition: color 0.3s ease;
 }
 
 .item-title a:hover {
-    color: #8B4513;
+    color: var(--teal-main);
 }
 
 .item-price {
@@ -209,13 +273,13 @@
 }
 
 .price-promo {
-    color: #dc3545;
+    color: var(--teal-dark);
     font-weight: 500;
     font-size: 18px;
 }
 
 .price-current {
-    color: #8B4513;
+    color: var(--teal-main);
     font-weight: 500;
     font-size: 18px;
 }
@@ -224,15 +288,24 @@
 .quantity-form {
     display: flex;
     align-items: center;
-    gap: 15px;
+    gap: 10px;
 }
 
 .quantity-controls {
     display: flex;
     align-items: center;
-    border: 1px solid #ddd;
+    border: 1px solid var(--teal-soft);
     border-radius: 4px;
     overflow: hidden;
+}
+
+.item-quantity .quantity-form {
+    justify-content: flex-end;
+}
+
+.item-quantity label {
+    font-weight: 500;
+    color: var(--neutral-dark);
 }
 
 .qty-btn {
@@ -242,13 +315,13 @@
     height: 35px;
     cursor: pointer;
     font-size: 16px;
-    color: #666;
+    color: var(--neutral-text);
     transition: all 0.3s ease;
 }
 
 .qty-btn:hover {
-    background-color: #f0f0f0;
-    color: #8B4513;
+    background-color: var(--teal-soft-alt);
+    color: var(--teal-main);
 }
 
 .qty-input {
@@ -256,14 +329,14 @@
     height: 35px;
     text-align: center;
     border: none;
-    border-left: 1px solid #ddd;
-    border-right: 1px solid #ddd;
+    border-left: 1px solid var(--teal-soft);
+    border-right: 1px solid var(--teal-soft);
     font-size: 14px;
     outline: none;
 }
 
 .btn-update {
-    background-color: #8B4513;
+    background-color: var(--teal-dark);
     color: #fff;
     border: none;
     padding: 8px 16px;
@@ -274,11 +347,13 @@
 }
 
 .btn-update:hover {
-    background-color: #D4AF37;
+    background-color: var(--teal-main);
+    box-shadow: 0 4px 12px rgba(27, 77, 77, 0.2);
 }
 
 .btn-update:disabled {
-    background-color: #ccc;
+    background-color: var(--teal-soft);
+    color: var(--neutral-text);
     cursor: not-allowed;
 }
 
@@ -290,35 +365,50 @@
     justify-content: space-between;
 }
 
+.subtotal-label {
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--neutral-text);
+    margin-bottom: 6px;
+}
+
 .subtotal-price {
     font-family: 'Cormorant Garamond', serif;
     font-size: 24px;
     font-weight: 500;
-    color: #8B4513;
+    color: var(--teal-dark);
+}
+
+.total-price {
+    color: var(--teal-dark);
 }
 
 .btn-remove {
-    color: #dc3545;
+    color: var(--teal-dark);
     text-decoration: none;
     font-size: 18px;
     padding: 8px;
+    border: 1px solid var(--teal-dark);
     border-radius: 50%;
     transition: all 0.3s ease;
     margin-top: 10px;
+    background-color: transparent;
 }
 
 .btn-remove:hover {
-    background-color: #dc3545;
+    background-color: var(--teal-main);
     color: #fff;
+    border-color: var(--teal-main);
 }
 
 /* Récapitulatif */
 .summary-card {
     background-color: #fff;
     padding: 30px;
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--teal-soft);
     border-radius: 8px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 12px rgba(27, 77, 77, 0.1);
     position: sticky;
     top: 120px;
 }
@@ -327,7 +417,7 @@
     font-family: 'Cormorant Garamond', serif;
     font-size: 28px;
     font-weight: 400;
-    color: #111;
+    color: var(--neutral-dark);
     margin-bottom: 25px;
     padding-bottom: 15px;
     border-bottom: 1px solid #f0f0f0;
@@ -346,7 +436,7 @@
     font-weight: 500;
     padding-top: 15px;
     border-top: 2px solid #f0f0f0;
-    color: #8B4513;
+    color: var(--teal-dark);
 }
 
 .summary-actions {
@@ -354,6 +444,35 @@
     display: flex;
     flex-direction: column;
     gap: 15px;
+}
+
+.payment-methods {
+    margin-top: 30px;
+    text-align: center;
+    color: var(--neutral-text);
+}
+
+.payment-methods p {
+    margin-bottom: 10px;
+    font-weight: 500;
+}
+
+.payment-icons {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    font-size: 2rem;
+    color: var(--teal-main);
+}
+
+.security-info {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px;
+    color: var(--teal-dark);
+    font-weight: 500;
 }
 
 .btn {
@@ -374,26 +493,43 @@
     font-family: 'Montserrat', sans-serif;
 }
 
+.btn-block {
+    width: 100%;
+    padding: 15px;
+    font-size: 1.1rem;
+}
+
 .btn-primary {
-    background-color: #8B4513;
+    background-color: var(--teal-dark);
     color: #fff;
 }
 
 .btn-primary:hover {
-    background-color: #D4AF37;
+    background-color: var(--teal-main);
     transform: translateY(-2px);
-    box-shadow: 0 4px 15px rgba(139, 69, 19, 0.3);
+    box-shadow: 0 4px 15px rgba(27, 77, 77, 0.25);
 }
 
 .btn-secondary {
     background-color: transparent;
-    color: #8B4513;
-    border: 1px solid #8B4513;
+    color: var(--teal-dark);
+    border: 1px solid var(--teal-dark);
 }
 
 .btn-secondary:hover {
-    background-color: #8B4513;
+    background-color: var(--teal-dark);
     color: #fff;
+}
+
+.btn-danger {
+    background-color: var(--teal-main);
+    color: #fff;
+}
+
+.btn-danger:hover {
+    background-color: var(--teal-accent);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(42, 115, 115, 0.2);
 }
 
 .btn-large {
@@ -414,11 +550,11 @@
     gap: 12px;
     margin-bottom: 12px;
     font-size: 14px;
-    color: #666;
+    color: var(--neutral-text);
 }
 
 .info-item i {
-    color: #8B4513;
+    color: var(--teal-dark);
     font-size: 16px;
     width: 20px;
 }
@@ -434,14 +570,14 @@
 .add-to-cart-form input[type="number"] {
     width: 80px;
     padding: 10px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--teal-soft);
     border-radius: 4px;
     text-align: center;
     font-size: 16px;
 }
 
 .btn-add-to-cart {
-    background-color: #8B4513;
+    background-color: var(--teal-dark);
     color: #fff;
     border: none;
     padding: 12px 25px;
@@ -458,13 +594,14 @@
 }
 
 .btn-add-to-cart:hover {
-    background-color: #D4AF37;
+    background-color: var(--teal-main);
     transform: translateY(-2px);
-    box-shadow: 0 4px 15px rgba(139, 69, 19, 0.3);
+    box-shadow: 0 4px 15px rgba(27, 77, 77, 0.25);
 }
 
 .btn-add-to-cart:disabled {
-    background-color: #ccc;
+    background-color: var(--teal-soft);
+    color: var(--neutral-text);
     cursor: not-allowed;
     transform: none;
     box-shadow: none;
@@ -478,21 +615,21 @@
 }
 
 .cart-badge a {
-    color: #111;
+    color: var(--neutral-dark);
     font-size: 20px;
     text-decoration: none;
     transition: color 0.3s ease;
 }
 
 .cart-badge a:hover {
-    color: #8B4513;
+    color: var(--teal-dark);
 }
 
 .cart-count {
     position: absolute;
     top: -8px;
     right: -8px;
-    background-color: #dc3545;
+    background-color: var(--teal-main);
     color: #fff;
     border-radius: 50%;
     width: 20px;
@@ -515,21 +652,42 @@
 }
 
 .notification.success {
-    background-color: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
+    background-color: var(--teal-soft);
+    color: var(--teal-dark);
+    border: 1px solid rgba(27, 77, 77, 0.15);
 }
 
 .notification.error {
-    background-color: #f8d7da;
-    color: #721c24;
-    border: 1px solid #f5c6cb;
+    background-color: var(--teal-soft-alt);
+    color: var(--teal-dark);
+    border: 1px solid rgba(27, 77, 77, 0.15);
 }
 
 .notification.info {
-    background-color: #d1ecf1;
-    color: #0c5460;
-    border: 1px solid #bee5eb;
+    background-color: #d9f0f0;
+    color: var(--teal-main);
+    border: 1px solid rgba(42, 115, 115, 0.2);
+}
+
+/* Alertes du panier */
+.alert {
+    padding: 15px 20px;
+    margin-bottom: 20px;
+    border-radius: 6px;
+    border: 1px solid rgba(27, 77, 77, 0.15);
+    background-color: var(--teal-soft-alt);
+    color: var(--teal-dark);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.alert-success {
+    background-color: var(--teal-soft);
+}
+
+.alert-error {
+    background-color: #f6eded;
+    border-color: rgba(27, 77, 77, 0.1);
 }
 
 /* Responsive Design */
@@ -538,20 +696,40 @@
         grid-template-columns: 1fr;
         gap: 40px;
     }
-    
+
     .summary-card {
         position: static;
     }
-    
+
     .panier-item {
-        grid-template-columns: 150px 1fr auto;
+        grid-template-columns: 140px 1fr;
         gap: 20px;
         padding: 20px;
     }
-    
+
     .item-image {
         width: 150px;
         height: 112px;
+    }
+
+    .item-quantity,
+    .item-subtotal,
+    .item-actions {
+        grid-column: 1 / -1;
+        justify-self: flex-start;
+    }
+
+    .item-quantity {
+        align-items: flex-start;
+    }
+
+    .item-subtotal {
+        align-items: flex-start;
+    }
+
+    .item-actions {
+        margin-top: 0;
+        justify-content: flex-start;
     }
 }
 
@@ -575,29 +753,38 @@
         gap: 15px;
         text-align: center;
     }
-    
+
     .item-image {
         width: 100%;
         height: 200px;
         margin: 0 auto;
     }
-    
+
     .item-details {
         text-align: center;
     }
-    
+
     .item-subtotal {
         align-items: center;
         flex-direction: row;
         justify-content: space-between;
     }
-    
+
+    .item-quantity {
+        align-items: center;
+    }
+
     .quantity-form {
         justify-content: center;
     }
-    
+
     .summary-actions {
         gap: 10px;
+    }
+
+    .panier-actions {
+        flex-direction: column;
+        align-items: stretch;
     }
 }
 


### PR DESCRIPTION
## Summary
- align the panier markup with the dedicated stylesheet classes and remove the inline style block
- refresh the panier stylesheet with the site's teal palette, shared button rules, and responsive refinements
- centralize alert, empty-state, action, and summary styling so both empty and filled carts share the consolidated CSS

## Testing
- php -l app/view/public/panier/panier.php

------
https://chatgpt.com/codex/tasks/task_b_68cd33977320833081251c94328a2e39